### PR TITLE
Don't set the cookie flag if it has a falsy value in the options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Simple API
-- Ultra-light (**409 bytes** gzipped)
+- Ultra-light (**424 bytes** gzipped)
 - Encoding of forbidden characters
 - Use as a [module](#module) or add to your [browser](#browser)
 

--- a/__tests__/hardtack.js
+++ b/__tests__/hardtack.js
@@ -20,12 +20,36 @@ describe('set', () => {
     expect(hardtack.set('name', user.name)).toBe(`name=${user.name}`);
   });
 
+  test('set with false flag', () => {
+    expect(
+      hardtack.set('name', user.name, {
+        secure: false,
+      })
+    ).toBe(`name=${user.name}`);
+  });
+
+  test('set with undefined flag', () => {
+    expect(
+      hardtack.set('name', user.name, {
+        secure: undefined,
+      })
+    ).toBe(`name=${user.name}`);
+  });
+
   test('set with iterable options', () => {
     expect(
       hardtack.set('name', user.name, {
         expires: options.expires,
       })
     ).toBe(`name=${user.name};expires=${options.expires}`);
+  });
+
+  test('set with maxAge of 0', () => {
+    expect(
+      hardtack.set('name', user.name, {
+        maxAge: 0,
+      })
+    ).toBe(`name=${user.name};max-age=0`);
   });
 
   test('set with maxAge', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardtack",
-  "description": "An ultra-light (409 bytes) library for working with cookies in JavaScript",
+  "description": "An ultra-light (414 bytes) library for working with cookies in JavaScript",
   "version": "4.0.1",
   "main": "dist/hardtack.cjs.js",
   "module": "dist/hardtack.esm.js",
@@ -20,7 +20,7 @@
   "size-limit": [
     {
       "path": "dist/hardtack.min.js",
-      "limit": "409 B",
+      "limit": "424 B",
       "webpack": false
     }
   ],

--- a/src/hardtack.js
+++ b/src/hardtack.js
@@ -8,6 +8,11 @@ export default {
       .map(optionName => {
         const optionValue = options[optionName];
 
+        // Skip option if the value is passed as false, null, or undefined,
+        // but don't ignore maxAge:0
+        if (optionValue === false || optionValue == null) {
+          return '';
+        }
         if (optionValue === true) {
           return `;${optionName}`;
         }


### PR DESCRIPTION
Hey, thanks for a nice lib!

I found it a bit unintuitive that a flag is set if I specify it with a falsy value in the options object, eg.:

```js
hardtack.set('foo', 'bar', {
  secure: location.protocol === 'https:'
});
```

Fix it by ignoring flags passed as `false`, `undefined`, or `null`, but don't break `maxAge: 0`.

Sorry for blowing the size budget ;)