### PR TITLE
fix: include typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.1",
   "files": [
     "index.js",
+    "index.d.ts",
     "src/**/*.js"
   ],
   "license": "MIT",


### PR DESCRIPTION
I see `index.d.ts` is included in the github repo, but it is not present in the npm package - see https://www.npmjs.com/package/hardtack?activeTab=code for proof . This makes TypeScript have no type declarations at all for `hardstack` currently.

Could we publish the package again, but with the typings inside of it?

This is probably regression caused by https://github.com/alik0211/hardtack/commit/1d21b221f98c0a9fe634246ed6757dee2b666f4e#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7 .

P.S. the `"types"` property in the `package.json` is not needed, because as said in https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package :

> if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js) you do not need to mark the types property